### PR TITLE
[FEAT] 뉴스 스크랩 저장 및 삭제

### DIFF
--- a/src/components/common/BookMark.jsx
+++ b/src/components/common/BookMark.jsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+// BookMark.jsx (수정)
+import React from "react"; // useState 제거
 import styled from "styled-components";
 
 const Img = styled.img`
@@ -11,17 +12,12 @@ const Button = styled.button`
 `;
 
 function BookMark({ width, height, isMarked, onBookmarkToggle }) {
-  const [isBookMarkded, setIsBookMarked] = useState(isMarked);
-
-  function changeBookMark() {
-    setIsBookMarked((prev) => !prev);
-    onBookmarkToggle();
-  }
+  // isMarked prop을 사용.  내부 상태를 사용하지 않음.
 
   return (
     <>
-      <Button onClick={changeBookMark}>
-        {isBookMarkded ? (
+      <Button onClick={onBookmarkToggle}>
+        {isMarked ? (
           <Img src="/images/bookmarked.png"></Img>
         ) : (
           <Img src="/images/unbookmarked.png"></Img>

--- a/src/pages/informationPages/NewsPage.jsx
+++ b/src/pages/informationPages/NewsPage.jsx
@@ -3,31 +3,36 @@ import React from "react";
 import NewsCard from "../../components/common/NewsCard"; // NewsCard import
 import VolumeInfo from "../../components/information/VolumeInfo";
 import styled from "styled-components";
+import { useLocation } from "react-router-dom";
 
-const NewsContainer = styled.div`
-  /* padding: 10px; */
-`;
+const NewsContainer = styled.div``;
 
 function NewsPage({ newsData }) {
+  const location = useLocation();
+  const { userId } = location.state || {}; // userId를 여기서 가져옵니다.
+  // userId가 null 또는 undefined일 때 빈 배열([])을 할당
+  const safeNewsData = newsData || [];
+
   return (
     <div>
       <VolumeInfo title="뉴스" />
       <NewsContainer>
-        {newsData && newsData.length > 0 ? (
-          newsData.map((item, index) => (
-            <NewsCard
-              key={index}
-              title={item.title}
-              content={item.content}
-              link={item.link}
-              pubDate={item.pubDate}
-              hasImage={item.hasImage}
-              image={item.image}
-              sourceName={item.sourceName}
-              sourceImage={item.sourceImage}
-              defaultBookmarked={item.defaultBookmarked}
-            />
-          ))
+        {safeNewsData.length > 0 ? (
+          safeNewsData.map(
+            (
+              item // map함수에 key 추가
+            ) => (
+              <NewsCard
+                key={item.link} // link를 고유한 key로 사용.  API에서 제공하는 고유 ID가 있다면 그것을 사용하는 것이 더 좋음.
+                title={item.title}
+                link={item.link}
+                pubDate={item.pubDate}
+                sourceName={item.sourceName}
+                defaultBookmarked={item.defaultBookmarked}
+                userId={userId} // userId를 NewsCard에 전달
+              />
+            )
+          )
         ) : (
           <p>뉴스를 불러오는 중...</p>
         )}


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- close #이슈번호 -->

close #150

## 📝 요약(Summary)

정보제공 페이지의 뉴스 페이지에서 특정 뉴스의 북마크를 클릭하면 DB에 저장됨.
마이페이지 스크랩한 뉴스에서 북마크를 클릭하면 DB에서 삭제됨

현재 뉴스페이지에서 뉴스를 스크랩하고 새로고침하면 북마크 표시가 저장되지 않는 문제가 있음.

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요.  -->

## 🛠️ PR 유형

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

- [ ] PR 제목 규칙에 맞게 작성 했나요?
- [ ] 관련된 이슈 번호를 작성했나요? (<!--- close #이슈번호 -->)
- [ ] 모든 변경 사항을 다시 한번 검토했나요?
